### PR TITLE
Change has to field in t/50objectpad.t

### DIFF
--- a/t/50objectpad.t
+++ b/t/50objectpad.t
@@ -8,19 +8,19 @@ use Test::More;
 use Object::Pad;
 
 class FooBar {
-	has $x :reader = [];
+	field $x :reader = [];
 	use Sub::HandlesVia::Declare '$x', Array => (
 		all_x => 'all',
 		add_x => 'push',
 	);
 
-	has @y;
+	field @y;
 	use Sub::HandlesVia::Declare '@y', (
 		all_y => 'all',
 		add_y => 'push',
 	);
 	
-	has %z;
+	field %z;
 	use Sub::HandlesVia::Declare '%z', (
 		all_z => 'all',
 		add_z => 'set',


### PR DESCRIPTION
Object::Pad has removed the 'has' keyword in version 0.813, thus breaks the testsuite. Object::Pad 0.66 introduces the 'field' keyword and should therefore be safe to use as the Object::Pad version required by the testsuite is 0.67.