### PR TITLE
Fix bug preventing Hash "exists" methods working

### DIFF
--- a/lib/Sub/HandlesVia/HandlerLibrary/Hash.pm
+++ b/lib/Sub/HandlesVia/HandlerLibrary/Hash.pm
@@ -234,7 +234,7 @@ sub exists {
 		args      => 1,
 		signature => [Str],
 		usage     => '$key',
-		template  => 'defined(($GET)->{$ARG})',
+		template  => 'exists(($GET)->{$ARG})',
 		documentation => 'Indicates whether a value exists in the hashref by its key.',
 		_examples => sub {
 			my ( $class, $attr, $method ) = @_;


### PR DESCRIPTION
Hi, am `exists` method generated with `handles_via => 'Hash'` is implemented using `defined` rather than `CORE::exists`, so it doesn't behave as expected.

This trivial patch seems to fix that.
